### PR TITLE
dataset2bag: Fix optional compressed_images

### DIFF
--- a/src/dataset2bag.cpp
+++ b/src/dataset2bag.cpp
@@ -627,11 +627,11 @@ int main(int argc, char** argv)
 			throw std::runtime_error("You need to specify a timestamps file");
 
 		std::string compression_format;
-		if (!is_video && options.count("compressed_images"))
+		if (!is_video && options.count("compressed_images")) {
 			compression_format = options["compressed_images"].as<std::string>();
 
-		if (compression_format != "jpg" && compression_format != "png") throw std::runtime_error("Only \"jpg\" or \"png\" compressed image formats are allowed");
-
+			if (compression_format != "jpg" && compression_format != "png") throw std::runtime_error("Only \"jpg\" or \"png\" compressed image formats are allowed");
+		}
 		if (options.count("calib") == 0 || (options.count("images_right") && !options.count("calib_right"))) throw std::runtime_error("Camera calibration is required");
 
 		/* load camera calibrations */


### PR DESCRIPTION
compressed_images option threw an error if not specified, stating that
only png or jpg was allowed. Make it actually optional. Now if it is
empty it doesn't write in topic ".../image_raw/compressed" but in
".../image_raw" instead as it was supposed to.

Signed-off-by: Hernán Gonzalez <hernan@vanguardiasur.com.ar>